### PR TITLE
fix: use OnceLock for password check variable

### DIFF
--- a/crates/database/src/password.rs
+++ b/crates/database/src/password.rs
@@ -1,27 +1,22 @@
 //! This file contains password related variables and functions used for the
 //! verification of the validity of a password provided by the user.
 
-use std::sync::{Arc, Mutex};
+use std::sync::OnceLock;
 
 use utils::password::Checks;
 
 use crate::prelude::*;
 
-lazy_static::lazy_static! {
-    /// Static variable used to store the checks to be made.
-    static ref PASSWORD_CHECKS: Arc<Mutex<Checks>> = Arc::new(Mutex::new(Checks::default()));
-}
+static PASSWORD_CHECKS: OnceLock<Checks> = OnceLock::new();
 
 /// Sets the checks to be done for the password verification.
 ///
 /// # Arguments
 /// * `checks` - Structure containing all checks to be made.
 pub fn set_checks(checks: Checks) {
-    if let Ok(mut value) = PASSWORD_CHECKS.lock() {
-        *value = checks;
-
+    if PASSWORD_CHECKS.set(checks.clone()).is_ok() {
         event!(Level::INFO, "✱ Password checks created");
-        event!(Level::TRACE, "{:#?}", *value);
+        event!(Level::TRACE, "{:#?}", checks);
     } else {
         event!(Level::ERROR, "Cannot apply password checks");
     }
@@ -32,9 +27,8 @@ pub fn set_checks(checks: Checks) {
 /// # Returns
 /// Checks structure or an error.
 pub fn checks() -> Res<Checks> {
-    if let Ok(value) = PASSWORD_CHECKS.lock() {
-        Ok((*value).clone())
-    } else {
-        Err(Error::PasswordChecksAccess)
-    }
+    PASSWORD_CHECKS
+        .get()
+        .ok_or(Error::PasswordChecksAccess)
+        .cloned()
 }


### PR DESCRIPTION
Avoid locking at each read access.

## Description

Use `OnceLock` to avoid locking the value at each read access.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Other

## Tests

- [ ] Unit tests have been added

## Relations (issues, documentation)

<!-- Please link to the issue here -->
