### PR TITLE
refactor: separate the Auth from the AuthStore

### DIFF
--- a/crates/auth/src/application/confirm_email.rs
+++ b/crates/auth/src/application/confirm_email.rs
@@ -16,7 +16,7 @@ pub struct ConfirmEmailStores {
 }
 
 /// User confirmation use-case structure.
-pub(crate) struct ConfirmEmail {
+pub struct ConfirmEmail {
     /// List of stores used.
     stores: ConfirmEmailStores,
 }

--- a/crates/auth/src/application/login.rs
+++ b/crates/auth/src/application/login.rs
@@ -1,44 +1,65 @@
 //! Use-case for login a user.
 
-use std::marker::PhantomData;
-
 use common_core::UseCase;
 
 use crate::domain::auth::{Auth, AuthCredentials};
 use crate::domain::port::AuthStore;
 use crate::prelude::*;
 
-/// Login use-case structure.
-pub(crate) struct Login<Store> {
-    /// Phantom data used to use the `Store` parameter in the struct.
-    _marker: PhantomData<Store>,
+/// Stores used by this use-case.
+pub struct LoginStores<A>
+where
+    A: AuthStore,
+{
+    /// Auth store.
+    pub auth: A,
 }
 
-impl<Store> Login<Store> {
+/// Login use-case structure.
+pub struct Login<A>
+where
+    A: AuthStore,
+{
+    /// List of stores used.
+    stores: LoginStores<A>,
+}
+
+impl<A> Login<A>
+where
+    A: AuthStore,
+{
     /// Creates a `Login` use-case instance.
+    ///
+    /// # Arguments
+    /// * `stores`: Stores used by this use-case.
     ///
     /// # Returns
     /// A `Login` instance.
-    pub fn new() -> Self {
-        Self {
-            _marker: PhantomData,
-        }
+    pub fn new(stores: LoginStores<A>) -> Self {
+        Self { stores }
     }
 }
 
-impl<Store> UseCase for Login<Store>
+impl<A> UseCase for Login<A>
 where
-    Store: AuthStore,
+    A: AuthStore,
 {
-    type Args = (Auth<Store>, AuthCredentials);
+    type Args = (Auth, AuthCredentials);
     type Output = ();
     type Error = Error;
 
     async fn handle(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
         let (mut auth, credentials) = args;
 
+        let user = self
+            .stores
+            .auth
+            .find_user_by_email(&credentials.email)
+            .await
+            .map_err(|_| Error::UserNotFound)?;
+
         // Try to authenticate the user (i.e. check if user exists and password are correct)
-        let user = auth.authenticate(credentials).await?;
+        let user = auth.authenticate(&user, &credentials).await?;
 
         // Check if the user is verified
         if !user.is_email_confirmed() {
@@ -46,6 +67,6 @@ where
         }
 
         // Create the session for this user
-        auth.login(&user.id).await
+        auth.login(&user).await
     }
 }

--- a/crates/auth/src/application/logout.rs
+++ b/crates/auth/src/application/logout.rs
@@ -1,36 +1,25 @@
 //! Use-case for logout a user.
 
-use std::marker::PhantomData;
-
 use common_core::UseCase;
 
 use crate::domain::auth::Auth;
-use crate::domain::port::AuthStore;
 use crate::prelude::*;
 
 /// Logout use-case structure.
-pub(crate) struct Logout<Store> {
-    /// Phantom data used to use the `Store` parameter in the struct.
-    _marker: PhantomData<Store>,
-}
+pub struct Logout {}
 
-impl<Store> Logout<Store> {
+impl Logout {
     /// Creates a `Logout` use-case instance.
     ///
     /// # Returns
     /// A `Logout` instance.
     pub fn new() -> Self {
-        Self {
-            _marker: PhantomData,
-        }
+        Self {}
     }
 }
 
-impl<Store> UseCase for Logout<Store>
-where
-    Store: AuthStore,
-{
-    type Args = Auth<Store>;
+impl UseCase for Logout {
+    type Args = Auth;
     type Output = ();
     type Error = Error;
 

--- a/crates/auth/src/application/mod.rs
+++ b/crates/auth/src/application/mod.rs
@@ -6,6 +6,6 @@ mod logout;
 mod send_email_confirmation;
 
 pub(crate) use confirm_email::{ConfirmEmail, ConfirmEmailStores};
-pub(crate) use login::Login;
+pub(crate) use login::{Login, LoginStores};
 pub(crate) use logout::Logout;
 pub(crate) use send_email_confirmation::{SendEmailConfirmation, SendEmailConfirmationStores};

--- a/crates/auth/src/application/send_email_confirmation.rs
+++ b/crates/auth/src/application/send_email_confirmation.rs
@@ -22,7 +22,7 @@ pub struct SendEmailConfirmationStores {
 }
 
 /// User confirmation use-case structure.
-pub(crate) struct SendEmailConfirmation {
+pub struct SendEmailConfirmation {
     /// Application configuration.
     config: Config,
 

--- a/crates/auth/src/extractor/auth_user.rs
+++ b/crates/auth/src/extractor/auth_user.rs
@@ -16,9 +16,8 @@ use crate::domain::error::Error;
 use crate::domain::port::AuthStore;
 use crate::infrastructure::SQLxAuthStore;
 
-// TODO: use generic
 #[async_trait]
-impl<S> FromRequestParts<S> for Auth<SQLxAuthStore>
+impl<S> FromRequestParts<S> for Auth
 where
     S: Send + Sync,
     AppState: FromRef<S>,
@@ -54,10 +53,6 @@ where
             None
         };
 
-        Ok(Auth {
-            user,
-            session,
-            store,
-        })
+        Ok(Auth { user, session })
     }
 }


### PR DESCRIPTION
## Description

Separate the `Auth` from the `AuthStore`.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Other

## Tests

- [ ] Unit tests have been added

## Relations (issues, documentation)

<!-- Please link to the issue here -->
